### PR TITLE
ignore files starting with _ when loading cogs

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -15,9 +15,9 @@ class Bot(commands.Bot):
         """Load all the extensions in the exts/ folder."""
         logger.info('Start loading extensions from ./exts/')
         for extension in constants.EXTENSIONS.glob("*/*.py"):
+            if extension.name[0] == "_":
+                continue  # ignore files starting with _
             dot_path = str(extension).replace("/", ".")[:-3]  # remove the .py
-            if "__init__" in dot_path:  # the __init__.py
-                continue
 
             self.load_extension(dot_path)
             logger.info(f"Successfully loaded extension:  {dot_path}")

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -15,7 +15,7 @@ class Bot(commands.Bot):
         """Load all the extensions in the exts/ folder."""
         logger.info('Start loading extensions from ./exts/')
         for extension in constants.EXTENSIONS.glob("*/*.py"):
-            if extension.name[0] == "_":
+            if extension.name.startswith("_"):
                 continue  # ignore files starting with _
             dot_path = str(extension).replace("/", ".")[:-3]  # remove the .py
 


### PR DESCRIPTION
this allows the user of util files in the category folders if they are prefixed with _.﻿
