### PR TITLE
Fix https://discord.com/channels/789192517375623228/793570459945926717/794026240767557664

### DIFF
--- a/bot/exts/utils/_eval_helper.py
+++ b/bot/exts/utils/_eval_helper.py
@@ -142,7 +142,7 @@ class EvalHelper:
             elif line.startswith("arguments "):
                 args.extend(line[10:].strip("`").split(" "))
             else:
-                code.append(line)
+                code.append(line.strip("`"))
 
         inputs = "\n".join(inputs)
         code = "\n".join(code)


### PR DESCRIPTION
**Problem:**  When flags such as `--wraped` is added, the `backticks` of the code block aren't removed, Hence the code sent to be compiled has backticks in it, causing the code to error out.

**Fix:** Before appending the code to the list `code`, It will run `.strip()` method, to remove the backticks.

**Example of Error:** https://discord.com/channels/789192517375623228/793570459945926717/794026240767557664

**Example of fix**
https://discord.com/channels/793864455527202847/793864455917797408/794026359931273216
