### PR TITLE
Correcting punctuation

### DIFF
--- a/bot/resources/bot_replies.yml
+++ b/bot/resources/bot_replies.yml
@@ -30,7 +30,7 @@ NEGATIVE_REPLIES: [
 ]
 
 POSITIVE_REPLIES : [
-    "Yep., Absolutely!",
+    "Yep. Absolutely!",
     "Can do!",
     "Affirmative!",
     "Yeah okay.",


### PR DESCRIPTION
Was skimming around the code base and stumbled upon this. Removing the `,` due to "Absolutely" being first-letter capitalized.