### PR TITLE
Support specifying top-level aliases in the command and group decorator

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -6,6 +6,7 @@ from functools import partial, partialmethod
 
 import loguru
 from bot.command import Command
+from bot.group import Group
 from discord.ext import commands
 from loguru import logger
 
@@ -33,3 +34,6 @@ logger.info("Logging Process Started")
 # Must be patched before any cogs are added.
 commands.command = partial(commands.command, cls=Command)
 commands.GroupMixin.command = partialmethod(commands.GroupMixin.command, cls=Command)
+
+commands.group = partial(commands.group, cls=Group)
+commands.GroupMixin.group = partialmethod(commands.GroupMixin.group, cls=Group)

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import os
 import typing
+from functools import partial, partialmethod
 
 import loguru
+from bot.command import Command
+from discord.ext import commands
 from loguru import logger
 
 from .constants import LOG_FILE
@@ -24,3 +27,9 @@ def should_rotate(message: loguru.Message, file: typing.TextIO) -> bool:
 
 logger.add(LOG_FILE, rotation=should_rotate)
 logger.info("Logging Process Started")
+
+
+# Monkey-patch discord.py decorators to use the Command subclass which supports root aliases.
+# Must be patched before any cogs are added.
+commands.command = partial(commands.command, cls=Command)
+commands.GroupMixin.command = partialmethod(commands.GroupMixin.command, cls=Command)

--- a/bot/command.py
+++ b/bot/command.py
@@ -1,0 +1,23 @@
+from discord.ext import commands
+
+
+class Command(commands.Command):
+    """
+    A `discord.ext.commands.Command` subclass which supports root aliases.
+
+    A `root_aliases` keyword argument is added, which is a sequence of alias names that will act as
+    top-level commands rather than being aliases of the command's group.
+
+    Example:
+        `!gh issue 72` can also be called as `!issue 72`.
+        `!gh src eval` can also be called as `!src eval`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.root_aliases = kwargs.get("root_aliases", [])
+
+        if not isinstance(self.root_aliases, (list, tuple)):
+            raise TypeError(
+                "Root aliases must bbe of type list or tuple, containing strings."
+            )

--- a/bot/exts/github/github.py
+++ b/bot/exts/github/github.py
@@ -1,5 +1,6 @@
 import typing
 
+from bot.bot import Bot
 from bot.constants import BOT_REPO_URL
 from discord import Embed
 from discord.ext import commands
@@ -18,7 +19,7 @@ class Github(commands.Cog):
         └ source        Displays information about the bot's source code.
     """
 
-    def __init__(self, bot: commands.Bot) -> None:
+    def __init__(self, bot: Bot) -> None:
         self.bot = bot
 
     @commands.group(name="github", aliases=("gh",), invoke_without_command=True)
@@ -26,7 +27,7 @@ class Github(commands.Cog):
         """Commands for Github."""
         await ctx.send_help(ctx.command)
 
-    @github_group.command(name="profile")
+    @github_group.command(name="profile", root_aliases=("profile",))
     @commands.cooldown(1, 10, BucketType.user)
     async def profile(self, ctx: commands.Context, username: str) -> None:
         """
@@ -39,7 +40,7 @@ class Github(commands.Cog):
 
         await ctx.send(embed=embed)
 
-    @github_group.command(name="issue", aliases=("pr",))
+    @github_group.command(name="issue", aliases=("pr",), root_aliases=("pr", "issue"))
     async def issue(
         self,
         ctx: commands.Context,
@@ -63,7 +64,11 @@ class Github(commands.Cog):
 
         await ctx.send(embed=embed)
 
-    @github_group.command(name="source", aliases=("src", "inspect"))
+    @github_group.command(
+        name="source",
+        aliases=("src", "inspect"),
+        root_aliases=("src", "inspect", "source"),
+    )
     async def source_command(
         self, ctx: commands.Context, *, source_item: typing.Optional[str] = None
     ) -> None:
@@ -86,6 +91,6 @@ class Github(commands.Cog):
         await ctx.send(embed=embed)
 
 
-def setup(bot: commands.Bot) -> None:
+def setup(bot: Bot) -> None:
     """Load the Github cog."""
     bot.add_cog(Github(bot))

--- a/bot/group.py
+++ b/bot/group.py
@@ -1,16 +1,16 @@
 from discord.ext import commands
 
 
-class Command(commands.Command):
+class Group(commands.Group):
     """
-    A `discord.ext.commands.Command` subclass which supports root aliases.
+    A `discord.ext.commands.Group` subclass which supports root aliases.
 
     A `root_aliases` keyword argument is added, which is a sequence of alias names that will act as
-    top-level commands rather than being aliases of the command's group.
+    top-level groups rather than being aliases of the group's group
 
     Example:
-        `!gh issue 72` can also be called as `!issue 72`.
-        `!gh src eval` can also be called as `!src eval`.
+        `!cmd gh issue 72` can also be called as `!gh issue 72`.
+        `!cmd src eval` can also be called as `!gh src eval`.
     """
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## Overview
Reference taken from python-discord/bot#1124.

A new keyword argument has been added to the `discord.ext.commands.GroupMixin.command (group)` decorators. The kwarg `root_aliases` allows a sequence of alias names to be specified which are meant to act as top-level commands and groups. For example,
```py
@github_group.command(name="issue", aliases=("pr",), root_aliases=("pr", "issue"))
```

### Example

```md
#Example for commands:
- `!gh issue 72` can also be called as `!issue 72`.
- `!gh src eval` can also be called as `!src eval`.

#Example for groups:
 - `!cmd gh issue 72` can also be called as `!gh issue 72`.
 - `!cmd src eval` can also be called as `!gh src eval`.
```

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
