### PR TITLE
Run linting workflow only on pushes to main branch or pull requests.

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,6 +1,10 @@
 name: Linting
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -3,7 +3,7 @@ name: Linting
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,10 +1,10 @@
 name: Linting
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
We don't want to build, lint (and deploy - In Future) on every branches, and currently the `Build` works after `Linting` which runs on every pull request or push to master, hence even running the `Build` workflow.

The reasons for not running them are:

- They are run twice.
  - In case of forks: On the pull request and the branch (mainly people push from separate branches, and not `main`)
  - In case of main: On the branch and the pull request.
