### PR TITLE
Fix indenation of code snippet sent on `!gh source` command

### DIFF
--- a/bot/exts/github/_source.py
+++ b/bot/exts/github/_source.py
@@ -1,5 +1,6 @@
 import re
 from inspect import getsourcelines
+from textwrap import dedent
 from typing import Optional
 
 import discord
@@ -37,6 +38,9 @@ class Source:
         sanitized = re.sub(doc_reg_class, "", sanitized)
         # The help argument of commands.command gets changed to `help=`
         sanitized = sanitized.replace("help=", 'help=""')
+
+        # Remove the extra indentation in the code.
+        sanitized = dedent(sanitized)
 
         if len(sanitized) > self.MAX_FIELD_LENGTH:
             sanitized = (


### PR DESCRIPTION
## Description
Use `textwrap.dedent` to remove the extra indentation present on the code snippet posted on executing `!gh src <command>` command.

## Reasoning
Currently it doesn't remove the indentation and uses the indentation present on the file, as a result looks messy, makes it unreadable and breaks the code lines.