### PR TITLE
feat: use discord timestamp in xkcd embed

### DIFF
--- a/bot/exts/fun/xkcd.py
+++ b/bot/exts/fun/xkcd.py
@@ -87,7 +87,9 @@ class XKCD(Cog):
         embed.url = f"{BASE_URL}/{info['num']}"
 
         if info["img"][-3:] in ("jpg", "png", "gif"):
-            date = datetime(year=int(info["year"]), month=int(info["month"]), day=int(info["day"]))
+            date = datetime(
+                year=int(info["year"]), month=int(info["month"]), day=int(info["day"])
+            )
             embed.timestamp = date
 
             embed.set_image(url=info["img"])

--- a/bot/exts/fun/xkcd.py
+++ b/bot/exts/fun/xkcd.py
@@ -1,7 +1,7 @@
 import logging
 import re
-from random import randint
 from datetime import datetime
+from random import randint
 from typing import Dict, Optional, Union
 
 from bot.bot import Bot

--- a/bot/exts/fun/xkcd.py
+++ b/bot/exts/fun/xkcd.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from random import randint
+from datetime import datetime
 from typing import Dict, Optional, Union
 
 from bot.bot import Bot
@@ -81,14 +82,16 @@ class XKCD(Cog):
                     await ctx.send(embed=embed)
                     return
 
-        embed.title = f"XKCD comic #{info['num']}"
+        embed.title = f"{info['safe_title']} (#{info['num']})"
         embed.description = info["alt"]
         embed.url = f"{BASE_URL}/{info['num']}"
 
         if info["img"][-3:] in ("jpg", "png", "gif"):
+            date = datetime(year=int(info["year"]), month=int(info["month"]), day=int(info["day"]))
+            embed.timestamp = date
+
             embed.set_image(url=info["img"])
-            date = f"{info['year']}/{info['month']}/{info['day']}"
-            embed.set_footer(text=f"{date} - #{info['num']}, '{info['safe_title']}'")
+            embed.set_footer(text=f"#{info['num']} • {info['safe_title']}")
             embed.colour = Colours.green
         else:
             embed.description = (


### PR DESCRIPTION
This PR makes it so the XKCD embed now uses the actual discord timestamp in the footer, and changes the title format to be the comic name, as was discussed in Discord. It looks like this:
![image](https://user-images.githubusercontent.com/16879430/115235838-894de980-a112-11eb-8240-67a511a2e92a.png)
![image](https://user-images.githubusercontent.com/16879430/115235853-8e129d80-a112-11eb-9a4c-6503240d009d.png)
![image](https://user-images.githubusercontent.com/16879430/115235874-92d75180-a112-11eb-850d-714df7bf1b1c.png)
