### PR TITLE
fix: remove sending command help

### DIFF
--- a/bot/exts/github/github.py
+++ b/bot/exts/github/github.py
@@ -75,7 +75,6 @@ class Github(commands.Cog):
             await ctx.send(embed=embed)
             return
         elif not ctx.bot.get_command(source_item):
-            await ctx.send_help(ctx.command)
             raise commands.BadArgument(
                 f"Unable to convert `{source_item}` to valid command or Cog."
             )


### PR DESCRIPTION
No need for sending command help as it is already included in the error message.

![image](https://user-images.githubusercontent.com/70969910/123300847-9b943b80-d538-11eb-906f-feefc396ea77.png)
