### PR TITLE
Logs: fix d.py 1.6 breaking change

### DIFF
--- a/bot/exts/moderation/logs.py
+++ b/bot/exts/moderation/logs.py
@@ -59,19 +59,21 @@ class ModerationLog(Cog):
         """Format and post a message to the #log channel."""
         logger.trace(f'Creating log "{actor.id} {action}"')
 
-        await self.post_message(
-            Embed(
-                title=(
-                    f"{actor} "
-                    f"{f'({actor.display_name}) ' if actor.display_name != actor.name else ''}"
-                    f"({actor.id}) {action}"
-                ),
-                description=body or "<no additional information provided>",
-                url=link,
-                colour=colour,
-                timestamp=datetime.utcnow(),
-            ).set_thumbnail(url=actor.avatar_url)
-        )
+        embed = Embed(
+            title=(
+                f"{actor} "
+                f"{f'({actor.display_name}) ' if actor.display_name != actor.name else ''}"
+                f"({actor.id}) {action}"
+            ),
+            description=body or "<no additional information provided>",
+            colour=colour,
+            timestamp=datetime.utcnow(),
+        ).set_thumbnail(url=actor.avatar_url)
+
+        if link:
+            embed.url = link
+
+        await self.post_message(embed=embed)
 
     @Cog.listener()
     async def on_raw_message_delete(self, payload: RawMessageDeleteEvent) -> None:


### PR DESCRIPTION
In 1.6, the great danny decided that Embed.url not being assignable to none wasn't a breaking change because it wasn't previously documented (Rapptz/discord.py#6657). Doesn't make any sense, but I guess we will have to roll with it.