### PR TITLE
Gurkcraft: automatically update channel topic

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -51,6 +51,7 @@ class Colours:
 
 class Channels(NamedTuple):
     off_topic = int(os.getenv("CHANNEL_OFF_TOPIC", 789198156218892358))
+    gurkcraft = int(os.getenv("CHANNEL_GURKCRAFT", 878159594189381662))
 
     devalerts = int(os.getenv("CHANNEL_DEVALERTS", 796695123177766982))
     devlog = int(os.getenv("CHANNEL_DEVLOG", 789431367167377448))

--- a/bot/exts/gurkcraft/gurkcraft.py
+++ b/bot/exts/gurkcraft/gurkcraft.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import discord
 from bot.constants import Channels, Colours, Minecraft
-from discord import TextChannel
+from discord import Embed, TextChannel
 from discord.ext import commands, tasks
 from discord.ext.commands import Bot
 from loguru import logger
@@ -28,7 +28,12 @@ class Gurkcraft(commands.Cog):
         except KeyError:
             players = ["None"]
         except OSError:
-            await ctx.send("The server is currently offline.")
+            await ctx.send(
+                embed=Embed(
+                    description="The server is currently offline.",
+                    colour=Colours.soft_red,
+                )
+            )
             return
 
         embed = discord.Embed(title="Gurkcraft", color=Colours.green)

--- a/bot/exts/gurkcraft/gurkcraft.py
+++ b/bot/exts/gurkcraft/gurkcraft.py
@@ -53,7 +53,7 @@ class Gurkcraft(commands.Cog):
 
     @tasks.loop(minutes=5)
     async def update_channel_description(self) -> None:
-        """Collect informations about the server and update the description of the channel."""
+        """Collect information about the server and update the description of the channel."""
         logger.debug("Updating topic of the #gurkcraft channel")
 
         if not self.gurkcraft:

--- a/bot/exts/gurkcraft/gurkcraft.py
+++ b/bot/exts/gurkcraft/gurkcraft.py
@@ -43,7 +43,7 @@ class Gurkcraft(commands.Cog):
         embed.add_field(name="Gurkans Connected", value=", ".join(players))
         await ctx.send(embed=embed)
 
-    @tasks.loop(minutes=2)
+    @tasks.loop(minutes=5)
     async def update_channel_description(self) -> None:
         """Collect informations about the server and update the description of the channel."""
         logger.debug("Updating topic of the #gurkcraft channel")

--- a/bot/exts/gurkcraft/gurkcraft.py
+++ b/bot/exts/gurkcraft/gurkcraft.py
@@ -1,7 +1,11 @@
+from typing import Optional
+
 import discord
-from bot.constants import Colours, Minecraft
-from discord.ext import commands
+from bot.constants import Channels, Colours, Minecraft
+from discord import TextChannel
+from discord.ext import commands, tasks
 from discord.ext.commands import Bot
+from loguru import logger
 from mcstatus import MinecraftServer
 
 
@@ -11,6 +15,9 @@ class Gurkcraft(commands.Cog):
     def __init__(self, bot: Bot) -> None:
         self.bot = bot
         self.server = MinecraftServer.lookup(Minecraft.server_address)
+        self.gurkcraft: Optional[TextChannel] = None
+
+        self.update_channel_description.start()
 
     @commands.command()
     async def mcstatus(self, ctx: commands.Context) -> None:
@@ -20,12 +27,56 @@ class Gurkcraft(commands.Cog):
             players = [user["name"] for user in status.raw["players"]["sample"]]
         except KeyError:
             players = ["None"]
+        except OSError:
+            await ctx.send("The server is currently offline.")
+            return
+
         embed = discord.Embed(title="Gurkcraft", color=Colours.green)
         embed.add_field(name="Server", value="mc.gurkult.com")
         embed.add_field(name="Server Latency", value=f"{status.latency}ms")
         embed.add_field(name="Gurkans Online", value=status.players.online)
         embed.add_field(name="Gurkans Connected", value=", ".join(players))
         await ctx.send(embed=embed)
+
+    @tasks.loop(minutes=2)
+    async def update_channel_description(self) -> None:
+        """Collect informations about the server and update the description of the channel."""
+        logger.debug("Updating topic of the #gurkcraft channel")
+
+        if not self.gurkcraft:
+            self.gurkcraft = await self.bot.fetch_channel(Channels.gurkcraft)
+
+            if not self.gurkcraft:
+                logger.warning(
+                    f"Failed to retrieve #gurkcraft channel {Channels.gurkcraft}. Aborting."
+                )
+                return
+
+        status = self.server.status()
+        is_online = True
+        try:
+            players = [user["name"] for user in status.raw["players"]["sample"]]
+        except KeyError:
+            players = []
+        except OSError:
+            is_online = False
+
+        if is_online:
+            description = (
+                "No players currently online. \n"
+                if not players
+                else (
+                    f"{status.players.online} player{'s' if len(players) > 1 else ''} "
+                    f"online: {', '.join(players)}. \n"
+                )
+                + f"Last server latency: {status.latency}ms"
+            )
+        else:
+            description = "The server is currently offline :("
+
+        await self.gurkcraft.edit(
+            topic=f"Our gurkan Minecraft server. Join: {Minecraft.server_address} ! \n{description}"
+        )
 
 
 def setup(bot: Bot) -> None:

--- a/bot/exts/gurkcraft/gurkcraft.py
+++ b/bot/exts/gurkcraft/gurkcraft.py
@@ -75,13 +75,12 @@ class Gurkcraft(commands.Cog):
 
         if is_online:
             description = (
-                "No players currently online. \n"
+                "No players currently online."
                 if not players
                 else (
                     f"{status.players.online} player{'s' if len(players) > 1 else ''} "
-                    f"online: {', '.join(players)}. \n"
+                    f"online: {', '.join(players)}."
                 )
-                + f"Last server latency: {status.latency}ms"
             )
         else:
             description = "The server is currently offline :("


### PR DESCRIPTION
Update the topic of the `#gurkcraft` channel to give some information about the status of the server. Here is an example:

![Screenshot_20210903_113511](https://user-images.githubusercontent.com/44778521/131985191-359c444f-a1a0-487e-a90b-835b9e4fca47.png)

It also makes `!mcstatus` gracefully handle `OSError`s.