### PR TITLE
Migration freeze

### DIFF
--- a/bot/exts/fun/off_topic.py
+++ b/bot/exts/fun/off_topic.py
@@ -103,6 +103,12 @@ class OffTopicNames(Cog):
     @off_topic_names.command(name="add", aliases=("a",))
     async def add_ot_name(self, ctx: Context, *, name: OT_Converter) -> None:
         """Add off topic channel name."""
+        # Migration freeze
+        await ctx.send(
+            ":x: Adding new names is currently disable due to an ongoing migration."
+        )
+        return
+
         if name in self.ot_names:
             await self._send_ot_embed(
                 ctx.channel, f":x:`{name}` already exists!", False

--- a/bot/exts/utils/reminder.py
+++ b/bot/exts/utils/reminder.py
@@ -73,6 +73,10 @@ class Reminder(Cog):
 
     async def send_reminder(self, reminder: Union[Record, dict]) -> None:
         """Send scheduled reminder."""
+        # During the migration no reminder will be sent,
+        # meaning they will all arrive once the migration is complete
+        return
+
         if (until := reminder["end_time"]) > datetime.utcnow():
             await sleep_until(until)
 
@@ -130,6 +134,10 @@ class Reminder(Cog):
             !remind 1hour30min workout
             !remind 20days1hour20min my birthday
         """
+        # Migration freeze
+        await ctx.send(
+            ":x: Adding new reminders is currently disable due to an ongoing migration."
+        )
         await self.remind_duration(ctx, duration, content=content)
 
     async def append_reminder(


### PR DESCRIPTION
This commits remove the ability to add new off-topic names, and receive and create reminders while a migration is being performed. Sorry for the inconvenience!