### PR TITLE
Logging: don't use files in prod

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -6,7 +6,7 @@ import typing
 import loguru
 from loguru import logger
 
-from .constants import LOG_FILE
+from .constants import ENVIRONMENT, LOG_FILE
 
 
 def should_rotate(message: loguru.Message, file: typing.TextIO) -> bool:
@@ -22,5 +22,6 @@ def should_rotate(message: loguru.Message, file: typing.TextIO) -> bool:
     return False
 
 
-logger.add(LOG_FILE, rotation=should_rotate)
+if ENVIRONMENT != "production":
+    logger.add(LOG_FILE, rotation=should_rotate)
 logger.info("Logging Process Started")

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -4,7 +4,8 @@ from typing import NamedTuple
 
 import yaml
 
-if os.getenv("ENVIRONMENT") is None:
+ENVIRONMENT = os.getenv("ENVIRONMENT")
+if ENVIRONMENT is None:
     from dotenv import load_dotenv
 
     load_dotenv(dotenv_path=f"{os.getcwd()}/.env")


### PR DESCRIPTION
As k8s is already storing logs, using temporary files in the pod isn't any useful.