### PR TITLE
feat: add test guild configuration for application commands

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,8 +1,8 @@
 TOKEN="your bot token here"  # here is a tutorial on how to get setup a bot and get this
 PREFIX="!"  # the prefix the bot should use, will default to "!" if this is not present
 
-# this is required if you do not want to wait up to an hour for commands to sync
-# eg: TEST_GUILDS="789192517375623228, 793864455527202847"
+# This is required if you do not want to wait up to an hour for commands to sync
+# Example: TEST_GUILDS=789192517375623228,793864455527202847
 TEST_GUILDS=
 
 CHANNEL_DEVALERTS=""

--- a/.env-example
+++ b/.env-example
@@ -1,6 +1,9 @@
 TOKEN="your bot token here"  # here is a tutorial on how to get setup a bot and get this
 PREFIX="!"  # the prefix the bot should use, will default to "!" if this is not present
 
+# this is required if you do not want to wait up to an hour for commands to sync
+TEST_GUILDS=
+
 CHANNEL_DEVALERTS=""
 CHANNEL_DEVLOG=""
 CHANNEL_DEV_GURKBOT=""

--- a/.env-example
+++ b/.env-example
@@ -2,6 +2,7 @@ TOKEN="your bot token here"  # here is a tutorial on how to get setup a bot and 
 PREFIX="!"  # the prefix the bot should use, will default to "!" if this is not present
 
 # this is required if you do not want to wait up to an hour for commands to sync
+# eg: TEST_GUILDS="789192517375623228, 793864455527202847"
 TEST_GUILDS=
 
 CHANNEL_DEVALERTS=""

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -32,9 +32,15 @@ class Bot(commands.Bot):
             ]
         ]
 
+        test_guilds = None
+        if constants.TEST_GUILDS:
+            logger.warning("Loading with test guilds.")
+            test_guilds = constants.TEST_GUILDS
+
         super().__init__(
             command_prefix=constants.PREFIX,
             intents=intents,
+            test_guilds=test_guilds,
             allowed_mentions=AllowedMentions(
                 everyone=None,
                 users=True,

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -24,6 +24,10 @@ EXTENSIONS = pathlib.Path("bot/exts/")
 LOG_FILE = pathlib.Path("log/gurkbot.log")
 
 
+if TEST_GUILDS := os.getenv("TEST_GUILDS"):
+    TEST_GUILDS = [int(x.strip()) for x in TEST_GUILDS.split(",")]
+
+
 class Emojis(NamedTuple):
     issue_emoji = "<:IssueOpen:794834041450266624>"
     issue_closed_emoji = "<:IssueClosed:794834041240289321>"

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -25,7 +25,7 @@ LOG_FILE = pathlib.Path("log/gurkbot.log")
 
 
 if TEST_GUILDS := os.getenv("TEST_GUILDS"):
-    TEST_GUILDS = [int(x.strip()) for x in TEST_GUILDS.split(",")]
+    TEST_GUILDS = [int(x) for x in TEST_GUILDS.split(",")]
 
 
 class Emojis(NamedTuple):


### PR DESCRIPTION
Adds a test guild configuration with an environment variable.

Without this option, commands register globally which means up to an hour of waiting for commands to be registered and appear in the test guild.